### PR TITLE
ＷＥＢアプリ開発２EX　２．マスタデータ（ジャンル）をデータベースで管理続き

### DIFF
--- a/web_application_2/src/components/Form.vue
+++ b/web_application_2/src/components/Form.vue
@@ -138,11 +138,7 @@ export default {
     },
     innerGenre: {
       get () {
-        const genre = {
-          genreCode: this.$props.editedItem.genre,
-          genreName: this.$props.editedItem.genre === '' ? '' : this.$store.getters['genreStore/genreItems'].find(genre => genre.genreCode === this.$props.editedItem.genre).genreName
-        }
-        return genre
+        return this.$store.getters['genreStore/getGenre'](this.$store.getters['searchStore/searchGenre'])
       },
       set (val) {
         this.$emit('changeGenre', val.genreCode)

--- a/web_application_2/src/components/Form.vue
+++ b/web_application_2/src/components/Form.vue
@@ -138,7 +138,7 @@ export default {
     },
     innerGenre: {
       get () {
-        return this.$store.getters['genreStore/getGenre'](this.$store.getters['searchStore/searchGenre'])
+        return this.$props.editedItem.genre
       },
       set (val) {
         this.$emit('changeGenre', val.genreCode)

--- a/web_application_2/src/components/Search.vue
+++ b/web_application_2/src/components/Search.vue
@@ -59,7 +59,7 @@ export default {
         return this.$store.getters['searchStore/searchTitle']
       },
       set (val) {
-        this.searchTitle = val
+        this.$emit('changeSearchTitle', val)
       }
     },
     searchGenre: {
@@ -72,7 +72,7 @@ export default {
       },
       set (val) {
         // クリアした場合undefinedになる
-        this.searchGenre.genreCode = typeof val === 'undefined' ? '' : val.genreCode
+        this.$emit('changeSearchGenre', typeof val === 'undefined' ? '' : val.genreCode)
       }
     },
     genreItems () {
@@ -82,7 +82,7 @@ export default {
   methods: {
     searchItem () {
       // 表示データ設定
-      this.$emit('searchResult', this.searchTitle, this.searchGenre.genreCode)
+      this.$emit('searchResult')
     }
   }
 }

--- a/web_application_2/src/components/Search.vue
+++ b/web_application_2/src/components/Search.vue
@@ -22,6 +22,7 @@
             item-text="genreName"
             item-value="genreCode"
             return-object
+            :clearable="true"
           ></v-select>
         </v-col>
         <v-col
@@ -50,11 +51,30 @@
 export default {
   data () {
     return {
-      searchTitle: '',
-      searchGenre: ''
     }
   },
   computed: {
+    searchTitle: {
+      get () {
+        return this.$store.getters['searchStore/searchTitle']
+      },
+      set (val) {
+        this.searchTitle = val
+      }
+    },
+    searchGenre: {
+      get () {
+        const genre = {
+          genreCode: this.$store.getters['searchStore/searchGenre'],
+          genreName: this.$store.getters['searchStore/searchGenre'] === '' ? '' : this.$store.getters['genreStore/genreItems'].find(genre => genre.genreCode === this.$store.getters['searchStore/searchGenre']).genreName
+        }
+        return genre
+      },
+      set (val) {
+        // クリアした場合undefinedになる
+        this.searchGenre.genreCode = typeof val === 'undefined' ? '' : val.genreCode
+      }
+    },
     genreItems () {
       return this.$store.getters['genreStore/genreItems']
     }

--- a/web_application_2/src/components/Search.vue
+++ b/web_application_2/src/components/Search.vue
@@ -64,7 +64,7 @@ export default {
     },
     searchGenre: {
       get () {
-        return this.$store.getters['genreStore/getGenre'](this.$store.getters['searchStore/searchGenre'])
+        return this.$store.getters['searchStore/searchGenre']
       },
       set (val) {
         // クリアした場合undefinedになる

--- a/web_application_2/src/components/Search.vue
+++ b/web_application_2/src/components/Search.vue
@@ -64,11 +64,7 @@ export default {
     },
     searchGenre: {
       get () {
-        const genre = {
-          genreCode: this.$store.getters['searchStore/searchGenre'],
-          genreName: this.$store.getters['searchStore/searchGenre'] === '' ? '' : this.$store.getters['genreStore/genreItems'].find(genre => genre.genreCode === this.$store.getters['searchStore/searchGenre']).genreName
-        }
-        return genre
+        return this.$store.getters['genreStore/getGenre'](this.$store.getters['searchStore/searchGenre'])
       },
       set (val) {
         // クリアした場合undefinedになる

--- a/web_application_2/src/store/genreStore.js
+++ b/web_application_2/src/store/genreStore.js
@@ -14,7 +14,15 @@ export default {
     }
   },
   getters: {
-    genreItems (state) { return state.genres }
+    genreItems (state) { return state.genres },
+    getGenre (state) {
+      return function (code) {
+        return {
+          genreCode: code,
+          genreName: code === '' ? '' : state.genres.find(genre => genre.genreCode === code).genreName
+        }
+      }
+    }
   },
   actions: {
     async doUpdate ({ commit }) {

--- a/web_application_2/src/store/genreStore.js
+++ b/web_application_2/src/store/genreStore.js
@@ -14,15 +14,7 @@ export default {
     }
   },
   getters: {
-    genreItems (state) { return state.genres },
-    getGenre (state) {
-      return function (code) {
-        return {
-          genreCode: code,
-          genreName: code === '' ? '' : state.genres.find(genre => genre.genreCode === code).genreName
-        }
-      }
-    }
+    genreItems (state) { return state.genres }
   },
   actions: {
     async doUpdate ({ commit }) {

--- a/web_application_2/src/store/index.js
+++ b/web_application_2/src/store/index.js
@@ -6,6 +6,7 @@ import Vuex from 'vuex'
 
 import templateStore from '@/store/templateStore'
 import genreStore from '@/store/genreStore'
+import searchStore from '@/store/searchStore'
 
 Vue.use(Vuex)
 
@@ -13,6 +14,7 @@ export default new Vuex.Store({
   namespaced: true,
   modules: {
     'templateStore': templateStore,
-    'genreStore': genreStore
+    'genreStore': genreStore,
+    'searchStore': searchStore
   }
 })

--- a/web_application_2/src/store/searchStore.js
+++ b/web_application_2/src/store/searchStore.js
@@ -1,0 +1,26 @@
+/* ------------------------------------------------------------------- *
+ * 検索条件ストア
+ * ------------------------------------------------------------------- */
+export default {
+  namespaced: true,
+  state: {
+    searchTitle: '',
+    searchGenre: ''
+  },
+  mutations: {
+    // 検索条件を変更するミューテーション
+    setSearchCondition (state, searchCondition) {
+      state.searchTitle = searchCondition.title
+      state.searchGenre = searchCondition.genre
+    }
+  },
+  getters: {
+    searchTitle (state) { return state.searchTitle },
+    searchGenre (state) { return state.searchGenre }
+  },
+  actions: {
+    doUpdate ({ commit }, searchCondition) {
+      commit('setSearchCondition', searchCondition)
+    }
+  }
+}

--- a/web_application_2/src/view/BookApp.vue
+++ b/web_application_2/src/view/BookApp.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <Search @searchResult="searchResult"></Search>
+    <Search @searchResult="searchResult"
+            @changeSearchTitle="changeSearchTitle"
+            @changeSearchGenre="changeSearchGenre">
+    </Search>
     <List :viewDesserts="viewDesserts"
           :confirmDialog="confirmDialog"
           @editOpen="editOpen"
@@ -55,10 +58,8 @@ export default Vue.extend({
     this.overlay = false
   },
   methods: {
-    async searchResult (searchTitle, searchGenre) {
-      this.searchTitle = searchTitle
-      this.searchGenre = searchGenre
-      this.$store.dispatch('searchStore/doUpdate', { title: searchTitle, genre: searchGenre })
+    async searchResult () {
+      this.$store.dispatch('searchStore/doUpdate', { title: this.searchTitle, genre: this.searchGenre })
       // 検索処理
       this.overlay = true
       try {
@@ -100,6 +101,12 @@ export default Vue.extend({
     confirmCancel () {
       // 削除確認画面ダイアログクローズ
       this.confirmDialog = false
+    },
+    changeSearchTitle (title) {
+      this.searchTitle = title
+    },
+    changeSearchGenre (genre) {
+      this.searchGenre = genre
     },
     gasRun (func, ...args) {
       return new Promise(function (resolve, reject) {

--- a/web_application_2/src/view/BookApp.vue
+++ b/web_application_2/src/view/BookApp.vue
@@ -45,7 +45,9 @@ export default Vue.extend({
     this.overlay = true
     try {
       await this.$store.dispatch('genreStore/doUpdate')
-      const result = await this.gasRun('getBooksTable', this.searchTitle, this.searchGenre, this.$store.getters['genreStore/genreItems'])
+      this.searchTitle = this.$store.getters['searchStore/searchTitle']
+      this.searchGenre = this.$store.getters['searchStore/searchGenre']
+      const result = await this.gasRun('getBooksTable', this.searchTitle, this.searchGenre)
       this.viewDesserts = cloneDeep(result)
     } catch (error) {
       alert('失敗しました' + error.message)
@@ -56,6 +58,7 @@ export default Vue.extend({
     async searchResult (searchTitle, searchGenre) {
       this.searchTitle = searchTitle
       this.searchGenre = searchGenre
+      this.$store.dispatch('searchStore/doUpdate', { title: searchTitle, genre: searchGenre })
       // 検索処理
       this.overlay = true
       try {


### PR DESCRIPTION
@hyamakawa(hansode)    @rikarin0308

ＷＥＢアプリ開発２おまけ　２．の続き、検索条件を各画面で引き継げるようにする　　の対応を行いましたので、
レビューをお願いします。（プルリクエスト先が変更になりますが、このタスクに関してはレビューをお願いします）

　やったこと
　　登録画面をダイアログから画面に変更したため、一覧画面に戻ったとき、検索条件が初期化されるため、
　　検索条件項目もVuex Storeを使って画面間で引き継げるようにする。
　　　①検索ボタン押下時に、検索条件項目をVuex Store機能を使ってストアの領域に保管する。
　　　②登録画面から戻ったとき、ストアの領域に保管した検索条件項目で再検索して表示する。
　　　③検索用コンポーネントのジャンルをクリアできるようにする


